### PR TITLE
Add script for expanded clock display

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dwmblocks-royarg-git
 	pkgdesc = A modified version of the modular status bar for dwm written in C.
-	pkgver = 1.0.r75.8f56741c
+	pkgver = 1.0.r76.131915c
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dwmblocks
 	install = dwmblocks-royarg-git.install
@@ -11,6 +11,7 @@ pkgbase = dwmblocks-royarg-git
 	depends = libx11
 	optdepends = acpilight: for controlling display backlight
 	optdepends = btop: system resource monitor
+	optdepends = figlet: expanded time display
 	optdepends = noto-fonts-emoji: for emoji support
 	optdepends = pulsemixer: for volume control
 	optdepends = ttf-joypixels: for emoji support

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dwmblocks"
 pkgname="$_pkgname-royarg-git"
-pkgver=1.0.r75.8f56741c
+pkgver=1.0.r76.131915c
 pkgrel=1
 pkgdesc="A modified version of the modular status bar for dwm written in C."
 arch=('x86_64')
@@ -11,6 +11,7 @@ depends=('sh' 'libx11')
 makedepends=('git')
 optdepends=('acpilight: for controlling display backlight'
   'btop: system resource monitor'
+  'figlet: expanded time display'
   'noto-fonts-emoji: for emoji support'
   'pulsemixer: for volume control'
   'ttf-joypixels: for emoji support'
@@ -28,7 +29,7 @@ md5sums=('SKIP')
 pkgver() {
   cd "$_pkgname"
   commits="$(git rev-list --count HEAD)"
-  gitref="$(git rev-parse --short=8 HEAD)"
+  gitref="$(git rev-parse --short=7 HEAD)"
   printf "1.0.r%s.%s" "$commits" "$gitref"
 }
 

--- a/dwmblocks-royarg-git.install
+++ b/dwmblocks-royarg-git.install
@@ -3,7 +3,7 @@
 post_install() {
   cat << END
 ╔════════════════════════════════════════════════════════════════════════════╗
-║ Scripts used by dwmblocks are available in "/bin" named "sb-*".            ║
+║ Scripts used by dwmblocks are available in "/usr/bin" named "sb-*".        ║
 ╚════════════════════════════════════════════════════════════════════════════╝
 END
 }


### PR DESCRIPTION
Also fix scripts path in post-install message

commit 131915caeb8225b03295717d7da8a0f1ee218b37
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Tue Jan 24 19:32:32 2023 +0530

    Add script to display time and calendar for sb-clock

    Uses figlet(1) if available with responsive output depending on the size
    of the terminal
