### PR TITLE
Fixes in sb-clock-display and sb-now-playing

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -9,7 +9,6 @@ pkgbase = dwmblocks-royarg-git
 	makedepends = git
 	depends = sh
 	depends = libx11
-	optdepends = acpilight: for controlling display backlight
 	optdepends = btop: system resource monitor
 	optdepends = figlet: expanded time display
 	optdepends = ncpamixer: audio mixer

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = dwmblocks-royarg-git
 	pkgdesc = A modified version of the modular status bar for dwm written in C.
-	pkgver = 1.0.r84.1a4abfb
+	pkgver = 1.0.r86.7d0fa72
 	pkgrel = 1
 	url = https://github.com/RoyARG02/dwmblocks
 	install = dwmblocks-royarg-git.install

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="dwmblocks"
 pkgname="$_pkgname-royarg-git"
-pkgver=1.0.r84.1a4abfb
+pkgver=1.0.r86.7d0fa72
 pkgrel=1
 pkgdesc="A modified version of the modular status bar for dwm written in C."
 arch=('x86_64')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,8 +9,7 @@ url="https://github.com/RoyARG02/$_pkgname"
 license=('ISC')
 depends=('sh' 'libx11')
 makedepends=('git')
-optdepends=('acpilight: for controlling display backlight'
-  'btop: system resource monitor'
+optdepends=('btop: system resource monitor'
   'figlet: expanded time display'
   'ncpamixer: audio mixer'
   'noto-fonts-emoji: for emoji support'


### PR DESCRIPTION
commit 7d0fa728531fa9b2f6d2324b99724a2944071702
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Tue May 2 20:25:06 2023 +0530

    [blocks] Show textual status in sb-now-playing on empty artist and title

commit 05436a62936dcadb889e6b738a7c5811b9f1cfb5
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Tue May 2 20:03:30 2023 +0530

    [blocks] Some fixes to sb-clock-display
    
    - 3 month view was always displaying the first 3 months of the year,
      fixed to display 3 months spanning the date
    - Breakpoints for calendar adjusted to accomodate months spanning 5
      weeks
